### PR TITLE
fix: correct brand name spelling and vendor list link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ This will place the ui components in the `packages/ui/src/components` directory.
 To use the components in your app, import them from the `ui` package.
 
 ```tsx
-import { Button } from "@ticketur/ui/components/button";
+import { Button } from "@ticketeur/ui/components/button";
 ```

--- a/apps/web/app/(app)/organizers/page.tsx
+++ b/apps/web/app/(app)/organizers/page.tsx
@@ -9,7 +9,7 @@ import { OrganisersTrust } from '@/components/sections/organisers/organisers-tru
 export const metadata: Metadata = {
   title: 'For Organizers',
   description:
-    'Empower your events with Ticketur — a secure, moderated marketplace for professional organisers to manage ticketing and vendors flawlessly.',
+    'Empower your events with Ticketeur — a secure, moderated marketplace for professional organisers to manage ticketing and vendors flawlessly.',
 }
 
 export default function OrganisersPage() {

--- a/apps/web/app/(app)/vendors/list/page.tsx
+++ b/apps/web/app/(app)/vendors/list/page.tsx
@@ -5,7 +5,7 @@ import { VendorListSection } from '@/components/sections/vendors/vendor-list-sec
 export const metadata: Metadata = {
   title: 'All Vendors',
   description:
-    "Browse Ticketur's curated roster of event professionals — from catering to audio/visual, security, and entertainment.",
+    "Browse Ticketeur's curated roster of event professionals — from catering to audio/visual, security, and entertainment.",
 }
 
 export default function VendorListPage() {

--- a/apps/web/app/(app)/vendors/page.tsx
+++ b/apps/web/app/(app)/vendors/page.tsx
@@ -9,7 +9,7 @@ import { VendorsModerated } from '@/components/sections/vendors/vendors-moderate
 export const metadata: Metadata = {
   title: 'For Vendors',
   description:
-    'Grow your business with Ticketur — join an elite community of verified vendors and showcase your brand at the most exclusive events.',
+    'Grow your business with Ticketeur — join an elite community of verified vendors and showcase your brand at the most exclusive events.',
 }
 
 export default function VendorsPage() {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -8,10 +8,10 @@ import { cn } from '@ticketur/ui/lib/utils'
 
 export const metadata: Metadata = {
   title: {
-    default: 'Ticketur',
-    template: '%s | Ticketur',
+    default: 'Ticketeur',
+    template: '%s | Ticketeur',
   },
-  description: 'Ticketur',
+  description: 'Ticketeur',
   icons: {
     icon: '/logo.svg',
   },

--- a/apps/web/components/layout/site-footer.tsx
+++ b/apps/web/components/layout/site-footer.tsx
@@ -40,12 +40,12 @@ export function SiteFooter() {
           <div className="flex max-w-104.25 flex-col gap-5.5">
             <Link
               href="/"
-              aria-label="Ticketur home"
+              aria-label="Ticketeur home"
               className="inline-flex items-center gap-2"
             >
               <LogoIcon className="h-10 w-auto" />
               <span className="font-heading text-foreground text-xl font-semibold tracking-tight md:text-[22px]">
-                Ticketur
+                Ticketeur
               </span>
             </Link>
             <p className="text-muted-foreground text-sm leading-relaxed">
@@ -104,7 +104,7 @@ export function SiteFooter() {
 
         <div className="border-border mt-10 flex flex-col-reverse items-center gap-4 border-t pt-8 md:mt-12 md:flex-row md:items-center md:justify-between">
           <p className="text-muted-foreground text-center text-xs md:text-left">
-            &copy; {year} Ticketur Inc. All rights reserved.
+            &copy; {year} Ticketeur Inc. All rights reserved.
           </p>
           <ThemeToggle />
         </div>

--- a/apps/web/components/layout/site-header.tsx
+++ b/apps/web/components/layout/site-header.tsx
@@ -70,7 +70,7 @@ export function SiteHeader() {
         <div className="mx-auto flex h-18 w-full max-w-360 items-center justify-between px-4 md:h-21 md:px-10">
           <Link
             href="/"
-            aria-label="Ticketur home"
+            aria-label="Ticketeur home"
             className="group flex items-center gap-2"
             onClick={() => setMobileOpen(false)}
           >
@@ -82,7 +82,7 @@ export function SiteHeader() {
               <LogoIcon className="h-9 w-auto md:h-10" />
             </motion.div>
             <span className="font-heading text-foreground text-xl font-semibold tracking-tight md:text-[22px]">
-              Ticketur
+              Ticketeur
             </span>
           </Link>
 

--- a/apps/web/components/sections/event-detail/checkout-view.tsx
+++ b/apps/web/components/sections/event-detail/checkout-view.tsx
@@ -220,7 +220,7 @@ export function CheckoutView({
             />
             <p className="text-sm text-[#92400e] dark:text-[#fbbf24]">
               <strong className="font-semibold">No-Refund Policy:</strong> All
-              sales are final. Since Ticketur is a moderated marketplace for
+              sales are final. Since Ticketeur is a moderated marketplace for
               community events, we cannot offer refunds once the purchase is
               complete.
             </p>

--- a/apps/web/components/sections/event-detail/ticket-selector.tsx
+++ b/apps/web/components/sections/event-detail/ticket-selector.tsx
@@ -180,7 +180,7 @@ export function TicketSelector({
                 className="text-primary size-4"
                 strokeWidth={1.8}
               />
-              <span>Secure checkout processed by Ticketur</span>
+              <span>Secure checkout processed by Ticketeur</span>
             </li>
             <li className="flex items-center gap-2">
               <HugeiconsIcon

--- a/apps/web/components/sections/event-detail/vendor-detail-view.tsx
+++ b/apps/web/components/sections/event-detail/vendor-detail-view.tsx
@@ -153,7 +153,7 @@ export function VendorDetailView({
               <QualityItem
                 icon={CheckmarkBadge02Icon}
                 title="Certified Partner"
-                description="Fully vetted and verified by the Ticketur platform."
+                description="Fully vetted and verified by the Ticketeur platform."
               />
             ) : null}
             {vendor.premium ? (

--- a/apps/web/components/sections/featured-vendors.tsx
+++ b/apps/web/components/sections/featured-vendors.tsx
@@ -72,7 +72,7 @@ export function FeaturedVendors() {
             </p>
           </div>
           <Link
-            href="/vendors"
+            href="/vendors/list"
             className="group text-primary hover:text-primary-hover inline-flex items-center gap-2 text-base font-medium transition-colors"
           >
             View all

--- a/apps/web/components/sections/organisers/organisers-cta.tsx
+++ b/apps/web/components/sections/organisers/organisers-cta.tsx
@@ -25,7 +25,7 @@ export function OrganisersCta() {
           Ready to host your next masterpiece?
         </h2>
         <p className="font-heading text-muted-foreground max-w-[680px] text-base leading-relaxed md:text-xl md:font-normal">
-          Join thousands of professional organizers who trust Ticketur for their
+          Join thousands of professional organizers who trust Ticketeur for their
           most important events.
         </p>
         <Button size="xl" asChild className="w-fit">

--- a/apps/web/components/sections/organisers/organisers-hero.tsx
+++ b/apps/web/components/sections/organisers/organisers-hero.tsx
@@ -25,7 +25,7 @@ export function OrganisersHero() {
               className="font-heading text-foreground text-4xl leading-[1.1] font-bold tracking-tight md:text-[52px] md:leading-[1.05] lg:text-[60px]"
             >
               Empower Your Events with{' '}
-              <span className="text-primary">Ticketur</span>
+              <span className="text-primary">Ticketeur</span>
             </h1>
             <p className="text-muted-foreground text-base leading-relaxed md:text-lg">
               Host your next event with confidence. Access a secure, moderated

--- a/apps/web/components/sections/organisers/organisers-trust.tsx
+++ b/apps/web/components/sections/organisers/organisers-trust.tsx
@@ -56,7 +56,7 @@ export function OrganisersTrust() {
               Built on a Foundation of Trust
             </h2>
             <p className="font-heading dark:text-muted-foreground text-sm leading-relaxed text-[#484848] md:text-lg md:font-normal">
-              Unlike other open marketplaces, Ticketur is a moderated platform.
+              Unlike other open marketplaces, Ticketeur is a moderated platform.
               Every organiser, vendor, and event is vetted to ensure high
               quality and prevent fraudulent activities. We protect your
               reputation and your revenue.

--- a/apps/web/components/sections/partner-with-us.tsx
+++ b/apps/web/components/sections/partner-with-us.tsx
@@ -92,7 +92,7 @@ export function PartnerWithUs() {
             </h2>
             <p className="dark:text-muted-foreground font-sans text-sm font-medium text-[#484848] md:text-base md:font-normal">
               Whether you&rsquo;re organizing an event or providing essential
-              services for events. Ticketur gives you the tools to grow and
+              services for events. Ticketeur gives you the tools to grow and
               manage your business securely.
             </p>
           </div>

--- a/apps/web/components/sections/vendor-detail/vendor-about.tsx
+++ b/apps/web/components/sections/vendor-detail/vendor-about.tsx
@@ -69,7 +69,7 @@ export function VendorAbout({ vendor }: { vendor: VendorRecord }) {
                 <QualityItem
                   icon={CheckmarkBadge02Icon}
                   title="Certified Partner"
-                  description="Fully vetted and verified by the Ticketur platform."
+                  description="Fully vetted and verified by the Ticketeur platform."
                 />
               ) : null}
               {vendor.premium ? (

--- a/apps/web/components/sections/vendors/vendors-hero.tsx
+++ b/apps/web/components/sections/vendors/vendors-hero.tsx
@@ -25,7 +25,7 @@ export function VendorsHero() {
               className="font-heading text-foreground text-4xl leading-[1.1] font-bold tracking-tight md:text-[52px] md:leading-[1.05] lg:text-[60px]"
             >
               Grow Your Business with{' '}
-              <span className="text-primary">Ticketur</span>
+              <span className="text-primary">Ticketeur</span>
             </h1>
             <p className="text-muted-foreground text-base leading-relaxed md:text-lg">
               Join an elite community of verified vendors and showcase your

--- a/apps/web/components/sections/vendors/vendors-moderated.tsx
+++ b/apps/web/components/sections/vendors/vendors-moderated.tsx
@@ -49,7 +49,7 @@ export function VendorsModerated() {
               A Moderated Ecosystem for Quality Brands
             </h2>
             <p className="dark:text-muted-foreground text-sm leading-relaxed text-[#484848] md:text-base">
-              Ticketur is not an open-for-all directory. We pride ourselves on
+              Ticketeur is not an open-for-all directory. We pride ourselves on
               manual moderation and brand verification. Every vendor on our
               platform meets strict quality guidelines, ensuring that organizers
               and attendees interact with only the most professional businesses.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ticketur",
+  "name": "ticketeur",
   "version": "0.0.1",
   "private": true,
   "scripts": {
@@ -10,8 +10,8 @@
     "typecheck": "turbo typecheck"
   },
   "devDependencies": {
-    "@ticketur/eslint-config": "workspace:*",
-    "@ticketur/typescript-config": "workspace:*",
+    "@ticketeur/eslint-config": "workspace:*",
+    "@ticketeur/typescript-config": "workspace:*",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "shadcn": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,10 +8,10 @@ importers:
 
   .:
     devDependencies:
-      '@ticketur/eslint-config':
+      '@ticketeur/eslint-config':
         specifier: workspace:*
         version: link:packages/eslint-config
-      '@ticketur/typescript-config':
+      '@ticketeur/typescript-config':
         specifier: workspace:*
         version: link:packages/typescript-config
       prettier:


### PR DESCRIPTION
- Replace all instances of "Ticketur" with "Ticketeur" across the web app
- Fix "View all" in featured-vendors section to link to /vendors/list